### PR TITLE
expose filesystem for url

### DIFF
--- a/src/ome_zarr_converters_tools/__init__.py
+++ b/src/ome_zarr_converters_tools/__init__.py
@@ -33,6 +33,7 @@ from ome_zarr_converters_tools.models import (
     SingleImage,
     StageOrientation,
     default_axes_builder,
+    filesystem_for_url,
     join_url_paths,
 )
 from ome_zarr_converters_tools.pipelines import (
@@ -68,6 +69,7 @@ __all__ = [
     "TiledImage",
     "converters_tools_models",
     "default_axes_builder",
+    "filesystem_for_url",
     "generic_compute_task",
     "join_url_paths",
     "setup_images_for_conversion",

--- a/src/ome_zarr_converters_tools/models/__init__.py
+++ b/src/ome_zarr_converters_tools/models/__init__.py
@@ -32,6 +32,7 @@ from ome_zarr_converters_tools.models._loader import (
     ImageLoaderInterfaceType,
 )
 from ome_zarr_converters_tools.models._url_utils import (
+    filesystem_for_url,
     find_url_type,
     join_url_paths,
     local_url_to_path,
@@ -39,7 +40,6 @@ from ome_zarr_converters_tools.models._url_utils import (
 
 __all__ = [
     "AcquisitionDetails",
-    "StagePositionCorrections",
     "BackendType",
     "ChannelInfo",
     "ChunkingStrategy",
@@ -58,9 +58,11 @@ __all__ = [
     "OverwriteMode",
     "SingleImage",
     "StageOrientation",
+    "StagePositionCorrections",
     "TilingMode",
     "WriterMode",
     "default_axes_builder",
+    "filesystem_for_url",
     "find_url_type",
     "join_url_paths",
     "local_url_to_path",


### PR DESCRIPTION
Expose this function to be used in other converters to read metadata files (like "MeasurementData.mlf" in fractal-uzh-converters).