### PR TITLE
Add `AUTODETECT` to `DataTypeEnum`

### DIFF
--- a/src/ome_zarr_converters_tools/core/_tile.py
+++ b/src/ome_zarr_converters_tools/core/_tile.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from ome_zarr_converters_tools.models._acquisition import (
     COO_SYSTEM_TYPE,
     AcquisitionDetails,
+    DataTypeEnum,
 )
 from ome_zarr_converters_tools.models._collection import (
     CollectionInterfaceType,
@@ -146,6 +147,6 @@ class Tile(BaseModel, Generic[CollectionInterfaceType, ImageLoaderInterfaceType]
 
     def find_data_type(self, resource: Any | None = None) -> str:
         """Find the data type of the image data."""
-        if self.acquisition_details.data_type is not None:
+        if self.acquisition_details.data_type != DataTypeEnum.AUTODETECT:
             return self.acquisition_details.data_type
         return self.image_loader.find_data_type(resource)

--- a/src/ome_zarr_converters_tools/fractal/_models.py
+++ b/src/ome_zarr_converters_tools/fractal/_models.py
@@ -62,7 +62,7 @@ class AcquisitionOptions(BaseModel):
     """Optional path to a condition table CSV file."""
     axes: str | None = None
     """Axes to use for the image data, e.g. "czyx"."""
-    data_type: DataTypeEnum | None = Field(default=None, title="Data Type")
+    data_type: DataTypeEnum = Field(default=DataTypeEnum.AUTODETECT, title="Data Type")
     """Data type of the image data."""
     stage_corrections: StageOrientation = Field(
         default_factory=StageOrientation, title="Stage Corrections"
@@ -105,7 +105,7 @@ class AcquisitionOptions(BaseModel):
         axes = self.to_axes_list()
         if axes is not None:
             updated_details.axes = axes
-        if self.data_type is not None:
+        if self.data_type != DataTypeEnum.AUTODETECT:
             updated_details.data_type = self.data_type
         if self.condition_table_path is not None:
             updated_details.condition_table_path = self.condition_table_path

--- a/src/ome_zarr_converters_tools/models/_acquisition.py
+++ b/src/ome_zarr_converters_tools/models/_acquisition.py
@@ -19,6 +19,7 @@ ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 class DataTypeEnum(StrEnum):
     """Data type enumeration."""
 
+    AUTODETECT = "autodetect"
     UINT8 = "uint8"
     UINT16 = "uint16"
     UINT32 = "uint32"
@@ -137,7 +138,7 @@ class AcquisitionDetails(BaseModel):
     )
 
     # Data type of the image data (if known)
-    data_type: DataTypeEnum | None = None
+    data_type: DataTypeEnum = DataTypeEnum.AUTODETECT
 
     # Condition table path (if applicable)
     condition_table_path: str | None = None

--- a/tests/unit/test_fractal_models.py
+++ b/tests/unit/test_fractal_models.py
@@ -49,7 +49,7 @@ class TestAcquisitionOptions:
         assert opts.channels is None
         assert opts.pixel_info is None
         assert opts.axes is None
-        assert opts.data_type is None
+        assert opts.data_type == DataTypeEnum.AUTODETECT
         assert opts.condition_table_path is None
         assert opts.filters == []
 


### PR DESCRIPTION
This is an example of how one could fix #40.

I'm mostly adding it so that I can use it in https://github.com/fractal-analytics-platform/fractal-uzh-converters/tree/new-task-tools while developing fractal-task-tools v0.5.0, but feel free to merge in case it seems relevant (cc @lorenzocerrone @jluethi).