### PR TITLE
Classify local windows and UNC paths as UrlType.LOCAL

### DIFF
--- a/src/ome_zarr_converters_tools/models/_collection.py
+++ b/src/ome_zarr_converters_tools/models/_collection.py
@@ -1,6 +1,6 @@
 """Models for defining regions to be converted into OME-Zarr format."""
 
-import re
+import re, os
 from typing import Any, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
@@ -36,7 +36,9 @@ CollectionInterfaceType = TypeVar("CollectionInterfaceType", bound=CollectionInt
 
 def sanitize_path(path: str) -> str:
     """Make sure path ends with .zarr and is a valid Zarr name."""
-    validate_zarr_name(path)
+    # only validate the basename of the path
+    # as full paths may contain characters that are not valid for Zarr group/dataset names
+    # e.g. C:\... on windows
     if not path.endswith(".zarr"):
         path = f"{path}.zarr"
     return path

--- a/src/ome_zarr_converters_tools/models/_collection.py
+++ b/src/ome_zarr_converters_tools/models/_collection.py
@@ -39,6 +39,7 @@ def sanitize_path(path: str) -> str:
     # only validate the basename of the path
     # as full paths may contain characters that are not valid for Zarr group/dataset names
     # e.g. C:\... on windows
+    validate_zarr_name(os.path.basename(path))
     if not path.endswith(".zarr"):
         path = f"{path}.zarr"
     return path

--- a/src/ome_zarr_converters_tools/models/_url_utils.py
+++ b/src/ome_zarr_converters_tools/models/_url_utils.py
@@ -1,3 +1,4 @@
+import ntpath
 from enum import Enum
 from logging import getLogger
 from pathlib import Path
@@ -14,7 +15,7 @@ class UrlType(Enum):
 
 
 def find_url_type(url: str) -> UrlType:
-    if url.startswith("/"):
+    if url.startswith("/") or ntpath.isabs(url):
         return UrlType.LOCAL
     elif url.startswith("s3://"):
         return UrlType.S3

--- a/src/ome_zarr_converters_tools/models/_url_utils.py
+++ b/src/ome_zarr_converters_tools/models/_url_utils.py
@@ -36,6 +36,11 @@ def join_url_paths(base_url: str, *paths: str) -> str:
     This is used instead of os.path.join or pathlib.Path to ensure
     support for both local and S3 URLs.
     """
+
+    # if local path handle platform-specific separators
+    if find_url_type(base_url) == UrlType.LOCAL:
+        return str(Path(base_url, *paths))
+
     # Ensure base_url does not end with a slash
     base_url = base_url.rstrip("/")
     # Iterate for all but the last path to avoid adding a trailing slash

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,6 +14,12 @@ class TestUrlUtils:
     def test_find_url_type_local(self) -> None:
         assert find_url_type("/some/path") == UrlType.LOCAL
 
+    def test_find_url_type_windows_drive_local(self) -> None:
+        assert find_url_type(r"C:\some\path\file.tif") == UrlType.LOCAL
+
+    def test_find_url_type_unc_local(self) -> None:
+        assert find_url_type(r"\\server\share\file.tif") == UrlType.LOCAL
+
     def test_find_url_type_s3(self) -> None:
         assert find_url_type("s3://my-bucket/key") == UrlType.S3
 


### PR DESCRIPTION
Sharing a fix for https://github.com/BioVisionCenter/ome-zarr-converters-tools/issues/44.

However, while the error described in the issue goes away, the next error occurs in the case of using windows paths:

```
Error: Invalid Zarr name
'S:\...'. Names
must only contain A-Z, a-z, 0-9, -, _, space, and . characters. Additionally, names cannot have leading or trailing
spaces, start with '__', or consist only of dots.
```