### PR TITLE
Separate UI model from acquisition model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ pixi.lock
 # zarr
 *.zarr
 data/
+
+# claude
+.claude/

--- a/src/ome_zarr_converters_tools/__init__.py
+++ b/src/ome_zarr_converters_tools/__init__.py
@@ -9,6 +9,7 @@ from ome_zarr_converters_tools.core import (
 )
 from ome_zarr_converters_tools.fractal import (
     AcquisitionOptions,
+    ChannelInfoUI,
     ConvertParallelInitArgs,
     ImageListUpdateDict,
     converters_tools_models,
@@ -49,6 +50,7 @@ __all__ = [
     "AcquisitionOptions",
     "AttributeType",
     "ChannelInfo",
+    "ChannelInfoUI",
     "ChunkingStrategy",
     "CollectionInterface",
     "CollectionInterfaceType",

--- a/src/ome_zarr_converters_tools/fractal/__init__.py
+++ b/src/ome_zarr_converters_tools/fractal/__init__.py
@@ -15,6 +15,7 @@ from ome_zarr_converters_tools.fractal._json_utils import (
 )
 from ome_zarr_converters_tools.fractal._models import (
     AcquisitionOptions,
+    ChannelInfoUI,
     ConvertParallelInitArgs,
     PixelSizeModel,
     converters_tools_models,
@@ -22,6 +23,7 @@ from ome_zarr_converters_tools.fractal._models import (
 
 __all__ = [
     "AcquisitionOptions",
+    "ChannelInfoUI",
     "ConvertParallelInitArgs",
     "ImageListUpdateDict",
     "PixelSizeModel",

--- a/src/ome_zarr_converters_tools/fractal/_models.py
+++ b/src/ome_zarr_converters_tools/fractal/_models.py
@@ -1,5 +1,7 @@
 """Models to be used with Fractal tasks API."""
 
+from enum import StrEnum
+
 from pydantic import BaseModel, Field
 
 from ome_zarr_converters_tools.models._acquisition import (
@@ -42,6 +44,61 @@ class PixelSizeModel(BaseModel):
     """
 
 
+named_colors = {
+    "Blue": "#0000FF",
+    "Red": "#FF0000",
+    "Yellow": "#FFFF00",
+    "Magenta": "#FF00FF",
+    "Cyan": "#00FFFF",
+    "Gray": "#808080",
+    "Green": "#00FF00",
+    "Orange": "#FF8000",
+    "Purple": "#8000FF",
+    "Teal": "#008080",
+    "Lime": "#00FF80",
+    "Amber": "#FFBF00",
+    "Pink": "#FF0080",
+    "Navy": "#000080",
+    "Maroon": "#800000",
+    "Olive": "#808000",
+    "Coral": "#FF7F50",
+    "Violet": "#EE82EE",
+}
+
+
+class DefaultColorConversion(StrEnum):
+    """Default color conversion for the channels."""
+
+    def to_hexstr(self) -> str:
+        color = named_colors.get(self.name)
+        if color is None:
+            raise ValueError(f"No default color found for {self.name=}")
+        return color
+
+
+DefaultColor = StrEnum(
+    "DefaultColor",
+    {name: f"{name} ({val})" for name, val in named_colors.items()},
+    type=DefaultColorConversion,
+)
+
+
+class ChannelInfoUI(BaseModel):
+    """Channel information."""
+
+    channel_label: str
+    """Label of the channel."""
+    wavelength_id: str | None = None
+    """
+    The wavelength ID of the channel.
+    This field can be used in some tasks as alternative to channel_label,
+    e.g. for multiplexed acquisitions it can be used for applying illumination
+    correction based on wavelength ID instead of channel name.
+    """
+    colors: DefaultColor = DefaultColor.Blue
+    """The color associated with the channel, e.g. for visualization purposes."""
+
+
 class AcquisitionOptions(BaseModel):
     """Acquisition options for conversion.
 
@@ -52,7 +109,7 @@ class AcquisitionOptions(BaseModel):
     details from AcquisitionDetails model.
     """
 
-    channels: list[ChannelInfo] | None = None
+    channels: list[ChannelInfoUI] | None = None
     """List of channel information."""
     pixel_info: PixelSizeModel | None = Field(
         default=None, title="Pixel Size Information"
@@ -97,7 +154,16 @@ class AcquisitionOptions(BaseModel):
         """
         updated_details = acquisition_details.model_copy()
         if self.channels is not None:
-            updated_details.channels = self.channels
+            _updated_channels = []
+            for channel in self.channels:
+                _updated_channels.append(
+                    ChannelInfo(
+                        channel_label=channel.channel_label,
+                        wavelength_id=channel.wavelength_id,
+                        colors=channel.colors.to_hexstr(),
+                    )
+                )
+            updated_details.channels = _updated_channels
         if self.pixel_info is not None:
             updated_details.pixelsize = self.pixel_info.pixelsize
             updated_details.z_spacing = self.pixel_info.z_spacing

--- a/src/ome_zarr_converters_tools/fractal/_models.py
+++ b/src/ome_zarr_converters_tools/fractal/_models.py
@@ -95,7 +95,7 @@ class ChannelInfoUI(BaseModel):
     e.g. for multiplexed acquisitions it can be used for applying illumination
     correction based on wavelength ID instead of channel name.
     """
-    colors: DefaultColor = DefaultColor.Blue
+    color: DefaultColor = DefaultColor.Blue
     """The color associated with the channel, e.g. for visualization purposes."""
 
 
@@ -160,7 +160,7 @@ class AcquisitionOptions(BaseModel):
                     ChannelInfo(
                         channel_label=channel.channel_label,
                         wavelength_id=channel.wavelength_id,
-                        colors=channel.colors.to_hexstr(),
+                        color=channel.color.to_hexstr(),
                     )
                 )
             updated_details.channels = _updated_channels

--- a/src/ome_zarr_converters_tools/models/_acquisition.py
+++ b/src/ome_zarr_converters_tools/models/_acquisition.py
@@ -33,53 +33,6 @@ def default_axes_builder(is_time_series: bool) -> list[CANONICAL_AXES_TYPE]:
         return ["c", "z", "y", "x"]
 
 
-class DefaultColors(StrEnum):
-    """Default colors for the channels."""
-
-    blue = "Blue (0000FF)"
-    red = "Red (FF0000)"
-    yellow = "Yellow (FFFF00)"
-    magenta = "Magenta (FF00FF)"
-    cyan = "Cyan (00FFFF)"
-    gray = "Gray (808080)"
-    green = "Green (00FF00)"
-    orange = "Orange (FF8000)"
-    purple = "Purple (8000FF)"
-    teal = "Teal (008080)"
-    lime = "Lime (00FF80)"
-    amber = "Amber (FFBF00)"
-    pink = "Pink (FF0080)"
-    navy = "Navy (000080)"
-    maroon = "Maroon (800000)"
-    olive = "Olive (808000)"
-    coral = "Coral (FF7F50)"
-    violet = "Violet (8000FF)"
-
-    def to_hex(self) -> str:
-        """Convert the color to hex format."""
-        _color_mapping = {
-            DefaultColors.blue: "#0000FF",
-            DefaultColors.red: "#FF0000",
-            DefaultColors.yellow: "#FFFF00",
-            DefaultColors.magenta: "#FF00FF",
-            DefaultColors.cyan: "#00FFFF",
-            DefaultColors.gray: "#808080",
-            DefaultColors.green: "#00FF00",
-            DefaultColors.orange: "#FF8000",
-            DefaultColors.purple: "#8000FF",
-            DefaultColors.teal: "#008080",
-            DefaultColors.lime: "#00FF80",
-            DefaultColors.amber: "#FFBF00",
-            DefaultColors.pink: "#FF0080",
-            DefaultColors.navy: "#000080",
-            DefaultColors.maroon: "#800000",
-            DefaultColors.olive: "#808000",
-            DefaultColors.coral: "#FF7F50",
-            DefaultColors.violet: "#8000FF",
-        }
-        return _color_mapping[self]
-
-
 class ChannelInfo(BaseModel):
     """Channel information."""
 
@@ -92,8 +45,11 @@ class ChannelInfo(BaseModel):
     e.g. for multiplexed acquisitions it can be used for applying illumination
     correction based on wavelength ID instead of channel name.
     """
-    colors: DefaultColors = DefaultColors.blue
-    """The color associated with the channel, e.g. for visualization purposes."""
+    colors: str | None = None
+    """
+    The color associated with the channel in hex format,
+    e.g. for visualization purposes.
+    """
 
 
 class StageOrientation(BaseModel):

--- a/src/ome_zarr_converters_tools/models/_acquisition.py
+++ b/src/ome_zarr_converters_tools/models/_acquisition.py
@@ -45,7 +45,9 @@ class ChannelInfo(BaseModel):
     e.g. for multiplexed acquisitions it can be used for applying illumination
     correction based on wavelength ID instead of channel name.
     """
-    colors: str | None = None
+    color: str | None = Field(
+        default=None, pattern=r"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+    )
     """
     The color associated with the channel in hex format,
     e.g. for visualization purposes.

--- a/src/ome_zarr_converters_tools/pipelines/_write_ome_zarr.py
+++ b/src/ome_zarr_converters_tools/pipelines/_write_ome_zarr.py
@@ -127,7 +127,7 @@ def build_channels_meta(tiled_image: TiledImage) -> list[Channel] | None:
         channel = Channel(
             label=channel.channel_label,
             wavelength_id=channel.wavelength_id,
-            channel_visualisation=ChannelVisualisation(color=channel.colors),
+            channel_visualisation=ChannelVisualisation(color=channel.color),
         )
         channels.append(channel)
     return channels

--- a/src/ome_zarr_converters_tools/pipelines/_write_ome_zarr.py
+++ b/src/ome_zarr_converters_tools/pipelines/_write_ome_zarr.py
@@ -127,7 +127,7 @@ def build_channels_meta(tiled_image: TiledImage) -> list[Channel] | None:
         channel = Channel(
             label=channel.channel_label,
             wavelength_id=channel.wavelength_id,
-            channel_visualisation=ChannelVisualisation(color=channel.colors.to_hex()),
+            channel_visualisation=ChannelVisualisation(color=channel.colors),
         )
         channels.append(channel)
     return channels

--- a/tests/integration/test_pipelines.py
+++ b/tests/integration/test_pipelines.py
@@ -225,9 +225,9 @@ class TestHCSPlateEndToEnd:
         for region in registered.regions:
             for s in region.roi.slices:
                 if s.start is not None:
-                    assert float(s.start) == int(
-                        s.start
-                    ), f"start={s.start} is not pixel-aligned"
+                    assert float(s.start) == int(s.start), (
+                        f"start={s.start} is not pixel-aligned"
+                    )
 
     def test_full_pipeline_writes_omezarr(self, tmp_path: Path) -> None:
         df = pd.read_csv(_HCS_EXAMPLE_DIR / "tiles.csv")
@@ -475,6 +475,6 @@ class TestNoTilingTranslation:
             resource=str(_HCS_DATA_DIR),
         )
         translation = omezarr.get_image().dataset.translation
-        assert all(
-            v == 0.0 for v in translation
-        ), f"Expected all-zero translation for AUTO tiling mode, got {translation}"
+        assert all(v == 0.0 for v in translation), (
+            f"Expected all-zero translation for AUTO tiling mode, got {translation}"
+        )

--- a/tests/unit/test_fractal_models.py
+++ b/tests/unit/test_fractal_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from ome_zarr_converters_tools.fractal._models import (
     AcquisitionOptions,
+    ChannelInfoUI,
     ConvertParallelInitArgs,
     PixelSizeModel,
     converters_tools_models,
@@ -92,8 +93,8 @@ class TestAcquisitionOptions:
             t_spacing=1.0,
         )
         new_channels = [
-            ChannelInfo(channel_label="GFP"),
-            ChannelInfo(channel_label="RFP"),
+            ChannelInfoUI(channel_label="GFP"),
+            ChannelInfoUI(channel_label="RFP"),
         ]
         opts = AcquisitionOptions(channels=new_channels)
         updated = opts.update_acquisition_details(acq)
@@ -101,6 +102,7 @@ class TestAcquisitionOptions:
         assert channels is not None
         assert len(channels) == 2
         assert channels[0].channel_label == "GFP"
+        assert channels[0].colors is not None
 
     def test_update_acquisition_details_pixel_info(self) -> None:
         acq = AcquisitionDetails(

--- a/tests/unit/test_fractal_models.py
+++ b/tests/unit/test_fractal_models.py
@@ -102,7 +102,7 @@ class TestAcquisitionOptions:
         assert channels is not None
         assert len(channels) == 2
         assert channels[0].channel_label == "GFP"
-        assert channels[0].colors is not None
+        assert channels[0].color is not None
 
     def test_update_acquisition_details_pixel_info(self) -> None:
         acq = AcquisitionDetails(

--- a/tests/unit/test_write_ome_zarr.py
+++ b/tests/unit/test_write_ome_zarr.py
@@ -245,9 +245,8 @@ class TestBuildChannelsMeta:
 
     def test_channel_color_hex(self) -> None:
         img = _make_tiled_image_with_channels(
-            channels=[ChannelInfo(channel_label="DAPI")]
+            channels=[ChannelInfo(channel_label="DAPI", colors="#0000FF")]
         )
         result = build_channels_meta(img)
         assert result is not None
-        # Default color is blue -> 0000FF (with or without # prefix)
         assert "0000FF" in result[0].channel_visualisation.color  # type: ignore

--- a/tests/unit/test_write_ome_zarr.py
+++ b/tests/unit/test_write_ome_zarr.py
@@ -245,7 +245,7 @@ class TestBuildChannelsMeta:
 
     def test_channel_color_hex(self) -> None:
         img = _make_tiled_image_with_channels(
-            channels=[ChannelInfo(channel_label="DAPI", colors="#0000FF")]
+            channels=[ChannelInfo(channel_label="DAPI", color="#0000FF")]
         )
         result = build_channels_meta(img)
         assert result is not None


### PR DESCRIPTION
This PR:
* Introduced a new `ChannelInfoUI` model in `fractal/_models.py` to represent channel information for UI purposes, including a new `DefaultColor` enum for managing color names and hex codes. 
* Removed the old `DefaultColors` enum and related color logic from `models/_acquisition.py`, simplifying the `ChannelInfo` model to accept a hex color string directly.