### PR TITLE
Fix plate overwrite bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.8.1]
+
+### Fix
+- Fix `setup_plates` silently reusing an existing plate instead of replacing it when `overwrite_mode=OVERWRITE`; the `OVERWRITE` branch now unconditionally calls `create_empty_plate(overwrite=True)` instead of falling through the open-or-create try/except.
+
 ## [v0.8.0]
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,9 +90,7 @@ dev = [
     "ruff",
 ]
 
-zarrs = [
-    "zarrs",
-]
+zarrs = ["zarrs"]
 
 docs = [
     "mkdocs==1.6.1",
@@ -159,6 +157,9 @@ ignore = [
 [tool.ruff.format]
 docstring-code-format = true
 skip-magic-trailing-comma = false # default is false
+
+[tool.ty.environment]
+python = ".pixi/envs/dev"
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]

--- a/src/ome_zarr_converters_tools/pipelines/_collection_setup.py
+++ b/src/ome_zarr_converters_tools/pipelines/_collection_setup.py
@@ -92,15 +92,32 @@ def setup_plates(
                     f"replace it, or "
                     f"overwrite_mode={OverwriteMode.EXTEND.value} to add to it."
                 )
-        try:
-            # This can only succeed in "extend" mode if the group already exists
-            plate = open_ome_zarr_plate(plante_url, cache=True)
-        except Exception:
+        if overwrite_mode == OverwriteMode.OVERWRITE:
             plate = create_empty_plate(
                 store=plante_url,
                 name=plate_path,
                 ngff_version=ngff_version,
                 overwrite=True,
+                cache=True,
+            )
+        elif overwrite_mode == OverwriteMode.EXTEND:
+            try:
+                plate = open_ome_zarr_plate(plante_url, cache=True)
+            except Exception:
+                plate = create_empty_plate(
+                    store=plante_url,
+                    name=plate_path,
+                    ngff_version=ngff_version,
+                    overwrite=True,
+                    cache=True,
+                )
+        else:
+            # NO_OVERWRITE — pre-flight check above already raised if plate existed
+            plate = create_empty_plate(
+                store=plante_url,
+                name=plate_path,
+                ngff_version=ngff_version,
+                overwrite=False,
                 cache=True,
             )
         existing_image = plate.images_paths()

--- a/tests/unit/test_collection_setup.py
+++ b/tests/unit/test_collection_setup.py
@@ -294,6 +294,55 @@ class TestSetupPlates:
                 overwrite_mode=OverwriteMode.NO_OVERWRITE,
             )
 
+    def test_overwrite_replaces_existing_plate(self, tmp_path: Path) -> None:
+        # Create plate with image in well A/1
+        images_a = _make_plate_tiled_images(num_images=1)
+        zarr_dir = str(tmp_path)
+        setup_plates(
+            zarr_dir=zarr_dir,
+            tiled_images=images_a,
+            overwrite_mode=OverwriteMode.OVERWRITE,
+        )
+        # Overwrite with a different image in well B/2
+        acq = AcquisitionDetails(
+            channels=[ChannelInfo(channel_label="DAPI")],
+            pixelsize=1.0,
+            z_spacing=1.0,
+            t_spacing=1.0,
+        )
+        coll = ImageInPlate(plate_name="TestPlate", row="B", column=2, acquisition=0)
+        tile = build_dummy_tile(
+            fov_name="FOV_new",
+            start=StartPosition(x=0, y=0),
+            shape=TileShape(x=64, y=64, z=1, c=1, t=1),
+            collection=coll,
+            acquisition_details=acq,
+        )
+        images_b = tiled_image_from_tiles(
+            tiles=[tile], converter_options=ConverterOptions()
+        )
+        setup_plates(
+            zarr_dir=zarr_dir,
+            tiled_images=images_b,
+            overwrite_mode=OverwriteMode.OVERWRITE,
+        )
+        plate = open_ome_zarr_plate(tmp_path / "TestPlate.zarr")
+        image_paths = plate.images_paths()
+        # Old plate (well A/1) must be gone; only new plate (well B/2) remains
+        assert len(image_paths) == 1
+        assert not any("A" in p for p in image_paths), (
+            f"Old well A image still present after OVERWRITE: {image_paths}"
+        )
+
+    def test_no_overwrite_succeeds_when_plate_absent(self, tmp_path: Path) -> None:
+        images = _make_plate_tiled_images()
+        setup_plates(
+            zarr_dir=str(tmp_path),
+            tiled_images=images,
+            overwrite_mode=OverwriteMode.NO_OVERWRITE,
+        )
+        assert (tmp_path / "TestPlate.zarr").exists()
+
     def test_writes_condition_table(self, tmp_path: Path) -> None:
         images = _make_plate_tiled_images(attributes={"drug": ["DMSO"]})
         zarr_dir = str(tmp_path)


### PR DESCRIPTION
Fix `setup_plates` silently reusing an existing plate instead of replacing it when `overwrite_mode=OVERWRITE`; the `OVERWRITE` branch now unconditionally calls `create_empty_plate(overwrite=True)` instead of falling through the open-or-create try/except.